### PR TITLE
[fix] 코스 상세 응답값 변경

### DIFF
--- a/backend/src/main/java/com/mohaeng/backend/course/dto/request/CourseReq.java
+++ b/backend/src/main/java/com/mohaeng/backend/course/dto/request/CourseReq.java
@@ -1,12 +1,11 @@
 package com.mohaeng.backend.course.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -16,6 +15,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CourseReq {
     @NotBlank
+    @Length(min = 4, max = 20)
     private String title;
     @NotNull
     private String startDate;
@@ -28,6 +28,8 @@ public class CourseReq {
     private String region;
 
     private String thumbnailUrl;
+    @NotBlank
+    @Length(min = 10, max = 300)
     private String content;
     @NotEmpty
     private List<Long> placeIds = new ArrayList<>();

--- a/backend/src/main/java/com/mohaeng/backend/course/dto/request/CourseUpdateReq.java
+++ b/backend/src/main/java/com/mohaeng/backend/course/dto/request/CourseUpdateReq.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -17,6 +18,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CourseUpdateReq {
     @NotBlank
+    @Length(min = 4, max = 20)
     private String title;
     @NotNull
     private String startDate;
@@ -29,6 +31,8 @@ public class CourseUpdateReq {
     private String region;
 
     private String thumbnailUrl;
+    @NotBlank
+    @Length(min = 10, max = 300)
     private String content;
     @NotEmpty
     private List<Long> placeIds = new ArrayList<>();

--- a/backend/src/main/java/com/mohaeng/backend/course/dto/response/CourseRes.java
+++ b/backend/src/main/java/com/mohaeng/backend/course/dto/response/CourseRes.java
@@ -16,6 +16,7 @@ public class CourseRes {
     private Long courseId;
     private String title;
     private String nickname;
+    private String profileImgUrl;
     private Integer likeCount;
     private String courseDays;
     private String region;
@@ -29,11 +30,12 @@ public class CourseRes {
     private Boolean isBookmarked;
 
     @Builder
-    public CourseRes(Long courseId, String title, String nickname, Integer likeCount, String courseDays, String region, Boolean isPublished, LocalDateTime createdDate, String startDate, String endDate,
+    public CourseRes(Long courseId, String title, String nickname, String profileImgUrl, Integer likeCount, String courseDays, String region, Boolean isPublished, LocalDateTime createdDate, String startDate, String endDate,
                      String content, List<CourseInPlaceDto> places, Boolean isLiked, Boolean isBookmarked) {
         this.courseId = courseId;
         this.title = title;
         this.nickname = nickname;
+        this.profileImgUrl = profileImgUrl;
         this.likeCount = likeCount;
         this.courseDays = courseDays;
         this.region = region;
@@ -53,6 +55,7 @@ public class CourseRes {
                 .courseId(course.getId())
                 .title(course.getTitle())
                 .nickname(course.getMember().getNickName())
+                .profileImgUrl(course.getMember().getImageURL())
                 .likeCount(course.getLikeCount())
                 .courseDays(course.getCourseDays())
                 .region(course.getRegion())


### PR DESCRIPTION
코스 상세 응답 값에 작성자의 프로필 이미지를 추가해주고, 코스 작성과 수정시 사용하는 Response에 validation을 추가했습니다.

This closes #203 