### PR TITLE
Fix : 유저 프로필 이미지 url  수정

### DIFF
--- a/backend/src/main/java/com/mohaeng/backend/course/dto/response/CourseRes.java
+++ b/backend/src/main/java/com/mohaeng/backend/course/dto/response/CourseRes.java
@@ -55,7 +55,7 @@ public class CourseRes {
                 .courseId(course.getId())
                 .title(course.getTitle())
                 .nickname(course.getMember().getNickName())
-                .profileImgUrl(course.getMember().getImageURL())
+                .profileImgUrl(course.getMember().getImageURL() + "/" +course.getMember().getImageName())
                 .likeCount(course.getLikeCount())
                 .courseDays(course.getCourseDays())
                 .region(course.getRegion())


### PR DESCRIPTION
코스 상세 Response에서 사용된 유저 프로필 이미지 url에 문제가 있어서 수정했습니다.