### PR TITLE
[Fix] 코스 제목 글자수 제한 변경

### DIFF
--- a/backend/src/main/java/com/mohaeng/backend/course/dto/request/CourseReq.java
+++ b/backend/src/main/java/com/mohaeng/backend/course/dto/request/CourseReq.java
@@ -15,7 +15,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CourseReq {
     @NotBlank
-    @Length(min = 4, max = 20)
+    @Length(min = 4, max = 25)
     private String title;
     @NotNull
     private String startDate;

--- a/backend/src/main/java/com/mohaeng/backend/course/dto/request/CourseUpdateReq.java
+++ b/backend/src/main/java/com/mohaeng/backend/course/dto/request/CourseUpdateReq.java
@@ -18,7 +18,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CourseUpdateReq {
     @NotBlank
-    @Length(min = 4, max = 20)
+    @Length(min = 4, max = 25)
     private String title;
     @NotNull
     private String startDate;


### PR DESCRIPTION
코스 작성, 수정시 코스 제목 길이의 제한 변경 25자까지 작성 가능하도록 수정했습니다.